### PR TITLE
Allow run target command without arguments: pplog ./superserver

### DIFF
--- a/cmd/pplog/main.go
+++ b/cmd/pplog/main.go
@@ -87,7 +87,7 @@ func main() {
 		showBuildInfo()
 		return
 	}
-	if flag.NArg() < 2 {
+	if flag.NArg() < 1 {
 		fmt.Println("Usage: pplog [-d] [-v] your_command arg arg arg...")
 		return
 	}


### PR DESCRIPTION
Problem: I'd like to run some server, that configured using ENV, with no any args.

Now pplog returns:
```
$ go run ./cmd/pplog/. your-server
Usage: pplog [-d] [-v] your_command arg arg arg...
```

Solution: allow 1 NArgs instead of 2.

After PR:
```
$ go run ./cmd/pplog/. your-server
2024-12-02T12:00:00-05:00 [INFO] OK source.file=/Users/slog/main.go source.function=main.main source.line=14 user=1
```