### PR TITLE
make diff between *nix and win builds according to signal support

### DIFF
--- a/cmd/pplog/signal_notwindows.go
+++ b/cmd/pplog/signal_notwindows.go
@@ -1,0 +1,31 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func catchSigChild(rd *io.PipeReader) {
+	catchSigChld := make(chan os.Signal, 1)
+	signal.Notify(catchSigChld, syscall.SIGCHLD)
+	go func() {
+		sig := <-catchSigChld
+		deb("catch signal: " + sig.String())
+		time.Sleep(time.Second) // we give a second to collect the last data; this signal obtaining from group, nor from direct child
+		rd.Close()
+	}()
+}
+
+func signalToCmd(cmd *exec.Cmd, sig os.Signal) {
+	err := cmd.Process.Signal(sig)
+	if err != nil {
+		printError(err)
+	}
+}

--- a/cmd/pplog/signal_windows.go
+++ b/cmd/pplog/signal_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+func catchSigChild(rd *io.PipeReader) {
+	// do nothing, windows does not support SIGCHLD
+}
+
+func signalToCmd(cmd *exec.Cmd, sig os.Signal) {
+	if sig == os.Interrupt {
+		// cmd.Process.Signal(os.Interrupt) returns an error on windows
+		// just skip, windows itself sends INT to all processes attached to console
+		return
+	}
+	err := cmd.Process.Signal(sig)
+	if err != nil {
+		printError(err)
+	}
+}


### PR DESCRIPTION
signal propagation works like a charm on linux, but there are issues with windows:
* build fails because of undefined SIGCHLD:
  ```
  $ GOOS=windows go build -o /tmp/pplog.exe ./cmd/pplog/.                                                                                                     1 ↵ 
  # github.com/michurin/human-readable-json-logging/cmd/pplog
  cmd/pplog/main.go:145:38: undefined: syscall.SIGCHLD
  ```
  
 * calling cmd.Process.Signal(sig) on windows returning an error:
   ```
   Error: not supported by windows
   ```
   but child process goes down anyway
   
  So, I've created two separate impl: for win and not-win OS
  
  Now, pplog can works on both, linux and win... And ctrl+C works fine too.
  
  Win cmd example:
  ```
  C:\Users\vshatskikh>.\pplog.exe -d .\graceful-srv.exe
DEBUG: CreateFile C:\Users\vshatskikh/pplog.env: The system cannot find the file specified.
DEBUG: no configuration file has been found
DEBUG: running: .\graceful-srv.exe
DEBUG: reader started
2024-06-03T00:32:44.7267165+03:00 [INFO] starting server...
2024-06-03T00:32:44.7406852+03:00 [INFO] working hard...
2024-06-03T00:32:45.7500835+03:00 [INFO] working hard...
DEBUG: propagating signal: interrupt
2024-06-03T00:32:46.6443649+03:00 [INFO] stopping server...
2024-06-03T00:32:46.7622406+03:00 [INFO] working hard...
2024-06-03T00:32:47.6586389+03:00 [INFO] stopping server...
2024-06-03T00:32:47.7699383+03:00 [INFO] working hard...
2024-06-03T00:32:48.6707891+03:00 [INFO] stopping server...
2024-06-03T00:32:48.7797949+03:00 [INFO] working hard...
2024-06-03T00:32:49.6762703+03:00 [INFO] done
DEBUG: subprocess is finished
DEBUG: reader is closed
DEBUG: reader finished

C:\Users\vshatskikh>
  ```