### PR TITLE
Updating CI stuff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,3 +43,4 @@ jobs:
         with:
           files: ./coverage.txt
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }} # required

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.22"
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v6
         with:
           version: "v1.59"
       - run: "go test -v -race -coverprofile=coverage.txt -covermode=atomic ./..."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - run: "go test -v -race -coverprofile=coverage.txt -covermode=atomic ./..."
         env:
           GOEXPERIMENT: nocoverageredesign
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           files: ./coverage.txt
           verbose: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           go-version: "1.22"
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: "v1.58"
+          version: "v1.59"
       - run: "go test -v -race -coverprofile=coverage.txt -covermode=atomic ./..."
         env:
           GOEXPERIMENT: nocoverageredesign

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,17 +1,11 @@
 linters:
   enable-all: true
   disable:
-      # deprecated
-    - deadcode
-    - exhaustivestruct
-    - golint
-    - ifshort
-    - interfacer
-    - maligned
-    - nosnakecase
-    - scopelint
-    - structcheck
-    - varcheck
+      # depricated
+    - execinquery
+      # disabled because Go version 1.21
+    - copyloopvar
+    - intrange
       # too hard
     - varnamelen
     - gomnd


### PR DESCRIPTION
Generally, to avoid tons of warnings about legacy nodejs.
Useful instructions: [1](https://docs.codecov.com/docs/adding-the-codecov-token), [2](https://github.com/codecov/codecov-action)