### PR TITLE
Swap child and parent: prevent pplog immediate interrupt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,3 +43,10 @@ jobs:
         with:
           files: ./coverage.txt
           verbose: true
+defaults:
+  run:
+    # NOTE: some of behavioral-tests requires tty... but
+    #
+    # GitHub Actions run without a TTY device. This is a workaround to get one,
+    # based on https://github.com/actions/runner/issues/241#issuecomment-2019042651
+    shell: 'script --return --quiet --log-out /dev/null --command "bash -e {0}"'

--- a/behavioral-tests/ctrl-c-graceful/custom-fake-server.sh
+++ b/behavioral-tests/ctrl-c-graceful/custom-fake-server.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+child_pid=
+
+xtrap() {
+    echo "Getting SIGNAL $1. Exiting"
+    kill -9 $child_pid
+    exit
+}
+
+trap "xtrap SIGINT" 2 # graceful shutdown handler
+
+echo "Arguments: $@"
+
+(
+    # pretending someone kills process
+    for i in "$@"; do
+      echo "Working hard on ${i}..."
+      sleep 5
+    done
+) &
+
+child_pid=$!
+
+wait

--- a/behavioral-tests/ctrl-c-graceful/custom-run.sh
+++ b/behavioral-tests/ctrl-c-graceful/custom-run.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# emulate terminal: run command in separate process group
+set -m
+(
+  go run ../../cmd/... ./custom-fake-server.sh ARG1 ARG2 ARG3 > output.log
+) &
+set +m
+child_pgid=${!}
+
+sleep 1 # allow to work a little
+kill -2 -${child_pgid} # emulate user's ctrl-C
+
+wait ${child_pgid}
+
+echo "ok"

--- a/behavioral-tests/ctrl-c-graceful/expected.log
+++ b/behavioral-tests/ctrl-c-graceful/expected.log
@@ -1,0 +1,3 @@
+INVALID JSON: "Arguments: ARG1 ARG2 ARG3"
+INVALID JSON: "Working hard on ARG1..."
+INVALID JSON: "Getting SIGNAL SIGINT. Exiting"


### PR DESCRIPTION
Problem:
If we get rid of signal handling at all, pplog will be stopped immediately on ctrl-c in the terminal, so it will not print logs during command shutdown

Solution:
Handle interrupt signal and allow target to shutdown gracefully, stop immediatly on the second interrupt

UPD:
need update tests, it works fine on local machine, but CI failed because of  "set: can't access tty; job control turned off"

UPD2:
Github actions run without TTY, but there is a workaround: [comment on issue 241](https://github.com/actions/runner/issues/241#issuecomment-2019042651)