### PR TITLE
Basic window support in subprocess mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,10 @@ jobs:
       - run: "go version"
       - run: "go build ./cmd/..."
       - run: "./behavioral-tests/run.sh"
-  build-windows: # TODO switch to windows-latest and run integration tests
+  x-build-windows:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    name: "Simple build on MS Windows"
+    name: "Simple build binary for MS Windows"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -39,6 +39,18 @@ jobs:
           GOOS: windows
           GOARCH: amd64
       - run: "file pplog.exe"
+  windows:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    name: "Build on MS Windows"
+    steps:
+      - uses: actions/checkout@v4
+      - run: "go version" # go1.21.11 # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+      - run: "go build ./cmd/..."
+      - run: "dir"
+      - run: "./pplog.exe -v"
+      - shell: bash # naked `echo` won't work on windows
+        run: "./pplog.exe -d bash -c 'echo \\{\\\"time\\\":\\\"2024-12-02T12:00:00Z\\\",\\\"level\\\":\\\"INFO\\\",\\\"msg\\\":\\\"Hello\\\"\\}'"
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,21 @@ jobs:
       - run: "go version"
       - run: "go build ./cmd/..."
       - run: "./behavioral-tests/run.sh"
+  build-windows: # TODO switch to windows-latest and run integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: "Simple build on MS Windows"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - run: "go version"
+      - run: "go build ./cmd/..."
+        env:
+          GOOS: windows
+          GOARCH: amd64
+      - run: "file pplog.exe"
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ We makes `message` green. Keep shaping your logs field by field.
 - In `PPLOG_ERRLINE` template:
     - `TEXT`
     - `BINARY` — does TEXT contains control characters
+- If `PPLOG_CHILD_MODE` not empty `pplog` runs in child mode as if it has `-c` switch
 
 ## Most common colors
 
@@ -166,6 +167,10 @@ Text colors          Text High            Background           Hi Background    
 ## TODO
 
 - Usage: show templates in debug mode
+- Behavior tests:
+    - `-c`
+    - `PPLOG_CHILD_MODE` environment variable
+    - basic `runs-on: windows-latest`
 - Docs: explain main features of binary: modes etc.
 - Docs: link to console control codes info
 - Docs: write template functions guide and examples
@@ -180,6 +185,18 @@ If you decided to use this code as library as part of your product, you have to 
 this tool provides `io.Writer` to pipe log stream. It is easiest way to modify behavior of logger, however
 it leads to overhead for extra marshaling/unmarshaling. However, as well as we use human readable logs in
 local environment only, it is acceptable to have a little overhead.
+
+### Subprocesses handling issues
+
+The problem is that many processes have to be synchronized: shell-process, pplog-process, target-process with all its children...
+
+Long story short, the most reliable mode is pipe mode:
+
+```sh
+./service |& pplog
+```
+
+TODO: Explain subprocess-mode and child-mode (`-c`)
 
 ### Line-by-line processing
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Text colors          Text High            Background           Hi Background    
     - `-c`
     - `PPLOG_CHILD_MODE` environment variable
     - basic `runs-on: windows-latest`
+    - passing exit code
 - Docs: explain main features of binary: modes etc.
 - Docs: link to console control codes info
 - Docs: write template functions guide and examples

--- a/README.md
+++ b/README.md
@@ -164,6 +164,48 @@ Text colors          Text High            Background           Hi Background    
 \e[37mWhite  \e[0m   \e[97mWhite  \e[0m   \e[47mWhite  \e[0m   \e[107mWhite  \e[0m
 ```
 
+## Run modes explanation
+
+### Pipe mode
+
+The most confident mode. In this mode your shell cares about all your processes. Just do
+
+```sh
+./service | pplog
+# or with redirections if you need to take both stderr and stdout
+./service 2>&1 | pplog
+# or the same redirections in modern shells
+./service |& pplog
+```
+
+### Simple subprocess mode
+
+If you say just like that:
+
+```sh
+pplog ./service
+```
+
+`pplog` runs `./servcie` as a child process and tries to manage it.
+
+If you press Ctrl-C, `pplog` sends `SIGINT`, `SIGTERM`, `SIGKILL` to its child consequently with 1s delay in between.
+
+`pplog` tries to wait child process exited and returns its exit code transparently.
+
+Obvious disadvantage is that `pplog` doesn't try to manage children of child (if any), daemons etc.
+
+### Child (or coprocess) mode
+
+In this mode `pplog` starts as a child of `./service`
+
+```sh
+pplog -c ./service
+```
+
+So, `./service` itself obtains all signals and Ctrl-Cs directly.
+
+However, there are disadvantages here too. `pplog` can not get `./service`s exit code. And this mode unavailable under MS Windows.
+
 ## TODO
 
 - Usage: show templates in debug mode
@@ -189,15 +231,9 @@ local environment only, it is acceptable to have a little overhead.
 
 ### Subprocesses handling issues
 
-The problem is that many processes have to be synchronized: shell-process, pplog-process, target-process with all its children...
+The problem is that many processes have to be synchronized: shell-process, pplog-process, target-process with all its children.
 
-Long story short, the most reliable mode is pipe mode:
-
-```sh
-./service |& pplog
-```
-
-TODO: Explain subprocess-mode and child-mode (`-c`)
+You are able to choose one of three modes: pipe-, subprocess- and child-mode. Each of them has its own disadvantages.
 
 ### Line-by-line processing
 

--- a/behavioral-tests/args-and-signals/custom-fake-server.sh
+++ b/behavioral-tests/args-and-signals/custom-fake-server.sh
@@ -2,7 +2,7 @@
 
 xtrap() {
     echo "Getting SIGNAL $1. Exiting"
-    exit
+    exit 0
 }
 
 trap "xtrap SIGINT" 2 # graceful shutdown handler

--- a/behavioral-tests/args-and-signals/custom-fake-server.sh
+++ b/behavioral-tests/args-and-signals/custom-fake-server.sh
@@ -2,7 +2,7 @@
 
 xtrap() {
     echo "Getting SIGNAL $1. Exiting"
-    exit 0
+    exit 0 # it must to be forced 0; some shells can return 130 by default
 }
 
 trap "xtrap SIGINT" 2 # graceful shutdown handler

--- a/behavioral-tests/args-and-signals/custom-run.sh
+++ b/behavioral-tests/args-and-signals/custom-run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-go run ../../cmd/... ./custom-fake-server.sh ARG1 ARG2 | tee output.log
+go run ../../cmd/... -c ./custom-fake-server.sh ARG1 ARG2 | tee output.log

--- a/behavioral-tests/run.sh
+++ b/behavioral-tests/run.sh
@@ -11,7 +11,7 @@ trap cleanup EXIT
 
 cd "$(dirname $0)"
 
-for cs in $(find . -mindepth 1 -maxdepth 1 -type d)
+for cs in $(find . -mindepth 1 -maxdepth 1 -type d | sort)
 do
     (
     cd $cs
@@ -23,5 +23,6 @@ do
     fi
     diff expected.log output.log # will cause interruption due to -e
     rm output.log
+    echo "OK: $cs"
     )
 done

--- a/cmd/pplog/const.go
+++ b/cmd/pplog/const.go
@@ -1,0 +1,3 @@
+package main
+
+const buffSize = 32768

--- a/cmd/pplog/main.go
+++ b/cmd/pplog/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/michurin/human-readable-json-logging/slogtotext"
 )
 
-//nolint:gochecknoglobals
 var (
 	debugFlag       = false
 	showVersionFlag = false
@@ -26,7 +25,7 @@ var (
 
 func deb(m string) {
 	if debugFlag {
-		fmt.Println("DEBUG: " + m) //nolint:forbidigo
+		fmt.Println("DEBUG: " + m)
 	}
 }
 
@@ -69,10 +68,10 @@ func normLine(t string) string {
 func showBuildInfo() {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		fmt.Println("Cannot get build info") //nolint:forbidigo
+		fmt.Println("Cannot get build info")
 		return
 	}
-	fmt.Println(info.String()) //nolint:forbidigo
+	fmt.Println(info.String())
 }
 
 func readEnvs() (string, string, bool) {
@@ -148,7 +147,7 @@ func main() {
 func printError(err error) { // TODO reconsider
 	pe := new(os.PathError)
 	if errors.As(err, &pe) {
-		if pe.Err == syscall.EBADF { //nolint:errorlint // fragile code; somehow syscall.Errno.Is doesn't recognize EBADF, so we unable to use errors.As
+		if pe.Err == syscall.EBADF { // fragile code; somehow syscall.Errno.Is doesn't recognize EBADF, so we unable to use errors.As
 			// maybe it is good idea just ignore SIGPIPE
 			fmt.Fprintf(os.Stderr, "PPLog: It seems output descriptor has been closed\n") // trying to report it to stderr
 			return
@@ -156,8 +155,8 @@ func printError(err error) { // TODO reconsider
 	}
 	xe := new(exec.ExitError)
 	if errors.As(err, &xe) {
-		fmt.Printf("exit code = %d: %s\n", xe.ExitCode(), xe.Error()) //nolint:forbidigo // just for information
+		fmt.Printf("exit code = %d: %s\n", xe.ExitCode(), xe.Error()) // just for information
 		return
 	}
-	fmt.Printf("Error: %s\n", err.Error()) //nolint:forbidigo
+	fmt.Printf("Error: %s\n", err.Error())
 }

--- a/cmd/pplog/main.go
+++ b/cmd/pplog/main.go
@@ -110,59 +110,6 @@ func prepareFormatters() (func([]slogtotext.Pair) error, func([]slogtotext.Pair)
 	return slogtotext.MustFormatter(os.Stdout, logLine), slogtotext.MustFormatter(os.Stdout, errLine)
 }
 
-func runSubprocessMode() {
-	deb("run subprocess mode")
-
-	target := flag.Args()
-	binary, err := exec.LookPath(target[0])
-	if err != nil {
-		panic(err)
-	}
-
-	r, w, err := os.Pipe()
-	if err != nil {
-		panic(err)
-	}
-
-	chFiles := make([]uintptr, 3) // in, out, err
-	chFiles[0] = r.Fd()
-	chFiles[1] = os.Stdout.Fd()
-	chFiles[2] = os.Stderr.Fd()
-
-	selfBinaty, err := exec.LookPath(os.Args[0])
-	if err != nil {
-		panic(err)
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	pid, err := syscall.ForkExec(selfBinaty, os.Args[:1], &syscall.ProcAttr{
-		Dir:   cwd,
-		Env:   os.Environ(),
-		Files: chFiles,
-		Sys:   nil,
-	})
-	if err != nil {
-		panic(selfBinaty + ": " + err.Error())
-	}
-	deb(fmt.Sprintf("subprocess pid: %d", pid))
-
-	err = syscall.Dup2(int(w.Fd()), syscall.Stdout) // os.Stdout = w
-	if err != nil {
-		panic(err)
-	}
-	err = syscall.Dup2(int(w.Fd()), syscall.Stderr) // os.Stderr = w
-	if err != nil {
-		panic(err)
-	}
-
-	err = syscall.Exec(binary, target, os.Environ())
-	if err != nil {
-		panic(binary + ": " + err.Error())
-	}
-}
-
 func runPipeMode() {
 	deb("run pipe mode")
 	f, g := prepareFormatters()

--- a/cmd/pplog/run.go
+++ b/cmd/pplog/run.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 )
 
-func runSubprocessMode() {
-	deb("run subprocess mode")
+func runSubprocessModeChild() {
+	deb("run child mode")
 
 	target := flag.Args()
 	binary, err := exec.LookPath(target[0])

--- a/cmd/pplog/run.go
+++ b/cmd/pplog/run.go
@@ -1,0 +1,65 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func runSubprocessMode() {
+	deb("run subprocess mode")
+
+	target := flag.Args()
+	binary, err := exec.LookPath(target[0])
+	if err != nil {
+		panic(err)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+
+	chFiles := make([]uintptr, 3) //nolint:mnd // in, out, err
+	chFiles[0] = r.Fd()
+	chFiles[1] = os.Stdout.Fd()
+	chFiles[2] = os.Stderr.Fd()
+
+	selfBinaty, err := exec.LookPath(os.Args[0])
+	if err != nil {
+		panic(err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	pid, err := syscall.ForkExec(selfBinaty, os.Args[:1], &syscall.ProcAttr{
+		Dir:   cwd,
+		Env:   os.Environ(),
+		Files: chFiles,
+		Sys:   nil,
+	})
+	if err != nil {
+		panic(selfBinaty + ": " + err.Error())
+	}
+	deb(fmt.Sprintf("subprocess pid: %d", pid))
+
+	err = syscall.Dup2(int(w.Fd()), syscall.Stdout) // os.Stdout = w
+	if err != nil {
+		panic(err)
+	}
+	err = syscall.Dup2(int(w.Fd()), syscall.Stderr) // os.Stderr = w
+	if err != nil {
+		panic(err)
+	}
+
+	err = syscall.Exec(binary, target, os.Environ())
+	if err != nil {
+		panic(binary + ": " + err.Error())
+	}
+}

--- a/cmd/pplog/run_common.go
+++ b/cmd/pplog/run_common.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/michurin/human-readable-json-logging/slogtotext"
+)
+
+func runSubprocessMode(lineFmt, errFmt func([]slogtotext.Pair) error) {
+	deb("run subprocess mode")
+
+	rd, wr := io.Pipe()
+
+	done := make(chan struct{})
+
+	go func() {
+		err := slogtotext.Read(rd, lineFmt, errFmt, 32768)
+		if err != nil {
+			deb("reader is finished with err: " + err.Error())
+			return
+		}
+		deb("reader is finished")
+		close(done)
+	}()
+
+	args := flag.Args()[1:]
+	command := flag.Args()[0]
+
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = wr
+	cmd.Stderr = wr
+
+	err := cmd.Run()
+	_ = rd.Close() // we have to do it to finalize reader
+	deb("subprocess is finished")
+	if err != nil {
+		printError(err)
+	}
+	exitCode := cmd.ProcessState.ExitCode() // exit code can be set even if error
+	if exitCode < 0 {
+		exitCode = 1
+	}
+
+	<-done
+
+	os.Exit(exitCode)
+}

--- a/cmd/pplog/run_common.go
+++ b/cmd/pplog/run_common.go
@@ -1,16 +1,20 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/michurin/human-readable-json-logging/slogtotext"
 )
 
-func runSubprocessMode(lineFmt, errFmt func([]slogtotext.Pair) error) {
+func runSubprocessMode(lineFmt, errFmt func([]slogtotext.Pair) error) { //nolint:funlen
 	deb("run subprocess mode")
 
 	rd, wr := io.Pipe()
@@ -36,17 +40,75 @@ func runSubprocessMode(lineFmt, errFmt func([]slogtotext.Pair) error) {
 	cmd.Stdout = wr
 	cmd.Stderr = wr
 
-	err := cmd.Run()
-	_ = rd.Close() // we have to do it to finalize reader
-	deb("subprocess is finished")
+	err := cmd.Start()
 	if err != nil {
-		printError(err)
-	}
-	exitCode := cmd.ProcessState.ExitCode() // exit code can be set even if error
-	if exitCode < 0 {
-		exitCode = 1
+		panic(err) // TODO
 	}
 
+	syncWait := make(chan error, 1)
+	go func() {
+		syncWait <- cmd.Wait()
+	}()
+
+	syncTerm := make(chan os.Signal, 1)
+	signal.Notify(syncTerm, os.Interrupt, syscall.SIGTERM)
+
+	syncSignal := make(chan os.Signal, 1)
+
+	syncForceDone := make(chan struct{})
+
+	exitCode := 0
+
+LOOP:
+	for {
+		select {
+		case err := <-syncWait: // have to break loop in this case
+			deb("subprocess waiting is done")
+			if err != nil {
+				xerr := new(exec.ExitError)
+				if errors.As(err, &xerr) {
+					exitCode = xerr.ExitCode()
+					if exitCode < 0 {
+						exitCode = 1
+					}
+					break LOOP
+				}
+				panic(err) // TODO
+			}
+			break LOOP
+		case sig := <-syncTerm:
+			deb("pplog gets " + sig.String())
+			syncSignal <- syscall.SIGINT
+		case sig := <-syncSignal:
+			deb("pplog sending " + sig.String() + " to subprocess")
+			err := cmd.Process.Signal(sig)
+			if err != nil {
+				panic(err) // TODO
+			}
+			switch sig {
+			case syscall.SIGINT:
+				go func() {
+					<-time.After(time.Second)
+					syncSignal <- syscall.SIGTERM
+				}()
+			case syscall.SIGTERM:
+				go func() {
+					<-time.After(time.Second)
+					syncSignal <- syscall.SIGKILL
+				}()
+			case syscall.SIGKILL:
+				go func() {
+					<-time.After(time.Second)
+					close(syncForceDone)
+				}()
+			}
+		case <-syncForceDone:
+			panic("it seems the process can not be stopped")
+		}
+	}
+
+	deb("stopping reader and waiting for it")
+	_ = wr.Close() // TODO check error
 	<-done
 
 	os.Exit(exitCode)

--- a/cmd/pplog/run_common.go
+++ b/cmd/pplog/run_common.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/michurin/human-readable-json-logging/slogtotext"
 )
@@ -28,6 +29,8 @@ func runSubprocessMode(lineFmt, errFmt func([]slogtotext.Pair) error) {
 
 	args := flag.Args()[1:]
 	command := flag.Args()[0]
+
+	deb("running subprocess: " + command + " " + strings.Join(args, " "))
 
 	cmd := exec.Command(command, args...)
 	cmd.Stdout = wr

--- a/cmd/pplog/run_common.go
+++ b/cmd/pplog/run_common.go
@@ -17,7 +17,7 @@ func runSubprocessMode(lineFmt, errFmt func([]slogtotext.Pair) error) {
 	done := make(chan struct{})
 
 	go func() {
-		err := slogtotext.Read(rd, lineFmt, errFmt, 32768)
+		err := slogtotext.Read(rd, lineFmt, errFmt, buffSize)
 		if err != nil {
 			deb("reader is finished with err: " + err.Error())
 			return

--- a/cmd/pplog/run_common.go
+++ b/cmd/pplog/run_common.go
@@ -111,7 +111,7 @@ LOOP:
 				}()
 			}
 		case <-syncForceDone:
-			panic("it seems the process can not be stopped")
+			panic("it seems the process cannot be stopped")
 		}
 	}
 

--- a/cmd/pplog/run_windows.go
+++ b/cmd/pplog/run_windows.go
@@ -4,44 +4,11 @@
 package main
 
 import (
-	"flag"
-	"io"
+	"fmt"
 	"os"
-	"os/exec"
-
-	"github.com/michurin/human-readable-json-logging/slogtotext"
 )
 
-func runSubprocessMode() {
-	deb("run subprocess mode (windows)")
-
-	rd, wr := io.Pipe()
-
-	f, g := prepareFormatters()
-	go func() {
-		err := slogtotext.Read(rd, f, g, 32768)
-		if err != nil {
-			deb("reader is finished with err: " + err.Error())
-			return
-		}
-		deb("reader is finished")
-	}()
-
-	args := flag.Args()[1:]
-	command := flag.Args()[0]
-
-	cmd := exec.Command(command, args...)
-	cmd.Stdout = wr
-	cmd.Stderr = wr
-
-	err := cmd.Run()
-	deb("subprocess is finished")
-	if err != nil {
-		printError(err)
-	}
-	exitCode := cmd.ProcessState.ExitCode() // exit code can be set even if error
-	if exitCode < 0 {
-		exitCode = 1
-	}
-	os.Exit(exitCode)
+func runSubprocessModeChild() {
+	fmt.Fprintln(os.Stderr, "Child mode is not supported in MS Windows")
+	os.Exit(1)
 }

--- a/cmd/pplog/run_windows.go
+++ b/cmd/pplog/run_windows.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"io"
 	"os"
@@ -15,8 +14,6 @@ import (
 
 func runSubprocessMode() {
 	deb("run subprocess mode (windows)")
-
-	ctx := context.Background()
 
 	rd, wr := io.Pipe()
 
@@ -33,7 +30,7 @@ func runSubprocessMode() {
 	args := flag.Args()[1:]
 	command := flag.Args()[0]
 
-	cmd := exec.CommandContext(ctx, command, args...)
+	cmd := exec.Command(command, args...)
 	cmd.Stdout = wr
 	cmd.Stderr = wr
 

--- a/cmd/pplog/run_windows.go
+++ b/cmd/pplog/run_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"context"
+	"flag"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/michurin/human-readable-json-logging/slogtotext"
+)
+
+func runSubprocessMode() {
+	deb("run subprocess mode (windows)")
+
+	ctx := context.Background()
+
+	rd, wr := io.Pipe()
+
+	f, g := prepareFormatters()
+	go func() {
+		err := slogtotext.Read(rd, f, g, 32768)
+		if err != nil {
+			deb("reader is finished with err: " + err.Error())
+			return
+		}
+		deb("reader is finished")
+	}()
+
+	args := flag.Args()[1:]
+	command := flag.Args()[0]
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Stdout = wr
+	cmd.Stderr = wr
+
+	err := cmd.Run()
+	deb("subprocess is finished")
+	if err != nil {
+		printError(err)
+	}
+	exitCode := cmd.ProcessState.ExitCode() // exit code can be set even if error
+	if exitCode < 0 {
+		exitCode = 1
+	}
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
My idea is that. @vitalyshatskikh 

Windows in subprocess mode can lost the tail of logging. It's ok, it will be known issue.

Work in progress
- [x] find ms windows and test behavior
- [x] write CI task for `run-on: windows-latest`
- [x] update readme: known issue

