### PR TITLE
Swap child and parent+windows integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,21 @@ jobs:
       - run: "go version"
       - run: "go build ./cmd/..."
       - run: "./behavioral-tests/run.sh"
+  build-windows: # TODO switch to windows-latest and run integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: "Simple build on MS Windows"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - run: "go version"
+      - run: "go build ./cmd/..."
+        env:
+          GOOS: windows
+          GOARCH: amd64
+      - run: "file pplog.exe"
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,10 @@ jobs:
       - run: "go version"
       - run: "go build ./cmd/..."
       - run: "./behavioral-tests/run.sh"
-  build-windows: # TODO switch to windows-latest and run integration tests
-    runs-on: ubuntu-latest
+  build-windows:
+    runs-on: windows-latest
     timeout-minutes: 10
-    name: "Simple build on MS Windows"
+    name: "Go build and behavioral tests on MS Windows"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -38,7 +38,9 @@ jobs:
         env:
           GOOS: windows
           GOARCH: amd64
-      - run: "file pplog.exe"
+      - run: |
+          .\behavioral-tests\run.ps1
+        shell: pwsh
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/behavioral-tests/args-and-signals/custom-fake-server.ps1
+++ b/behavioral-tests/args-and-signals/custom-fake-server.ps1
@@ -1,0 +1,15 @@
+Write-Output "Arguments: $args"
+
+$sendCtrlBreakScriptPath = Join-Path -Path $PSScriptRoot -ChildPath "custom-send-break.ps1"
+$proc = Start-Process -FilePath "powershell.exe" -ArgumentList "-File `"$sendCtrlBreakScriptPath`"" -PassThru -NoNewWindow
+
+try {
+    while ($true) {
+        Start-Sleep -Seconds 5
+    }
+} finally {
+    # windows does not allow to write into pipe after interruption (Write-Output)
+    # we can only write to console directly
+    Write-Host "Getting SIGNAL SIGINT. Exiting"
+}
+

--- a/behavioral-tests/args-and-signals/custom-run.ps1
+++ b/behavioral-tests/args-and-signals/custom-run.ps1
@@ -1,0 +1,13 @@
+try {
+    go run ..\..\cmd\... powershell .\custom-fake-server.ps1 ARG1 ARG2 |
+            Tee-Object -FilePath output.log
+} finally {
+    # there is windows limitation: Write-Output (write to pipe)
+    # does not write anything after interruption.
+    # we can write directly to console using Write-Host,
+    # but Tee-Object does not receive this record too.
+    # the only way to get record in output log file is
+    # to write it manually:
+    $msg = 'INVALID JSON: "Getting SIGNAL SIGINT. Exiting"'
+    $msg | Out-File -FilePath "output.log" -Append
+}

--- a/behavioral-tests/args-and-signals/custom-send-break.ps1
+++ b/behavioral-tests/args-and-signals/custom-send-break.ps1
@@ -1,0 +1,31 @@
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public class NativeMethods {
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool GenerateConsoleCtrlEvent(uint dwCtrlEvent, uint dwProcessGroupId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool FreeConsole();
+
+    public const uint CTRL_C_EVENT = 0;
+    public const uint CTRL_BREAK_EVENT = 1;
+}
+"@
+
+function Send-CtrlBreakEvent {
+    param (
+        [int]$parentPid
+    )
+
+    [NativeMethods]::GenerateConsoleCtrlEvent([NativeMethods]::CTRL_C_EVENT, 0)
+    [NativeMethods]::FreeConsole()
+}
+
+Write-Output 'Sleeping...'
+Start-Sleep -Seconds 1
+Write-Output 'Going to kill parent process...'
+
+$parentPid = (Get-WmiObject Win32_Process -Filter "ProcessId=$PID").ParentProcessId
+$null = Send-CtrlBreakEvent -parentPid $parentPid

--- a/behavioral-tests/fake-server.ps1
+++ b/behavioral-tests/fake-server.ps1
@@ -1,0 +1,3 @@
+Write-Output '{"time":"2024-12-02T12:00:00-05:00","level":"INFO","source":{"function":"main.main","file":"/Users/slog/main.go","line":14},"msg":"OK","user":1}'
+Write-Output 'Broken raw error message'
+Write-Output '{"time":"2024-12-02T12:05:00-05:00","level":"INFO","source":{"function":"main.main","file":"/Users/slog/main.go","line":14},"msg":"OK","user":2}'

--- a/behavioral-tests/pipe-mode/custom-run.ps1
+++ b/behavioral-tests/pipe-mode/custom-run.ps1
@@ -1,0 +1,3 @@
+powershell ..\fake-server.ps1 |
+        go run ..\..\cmd\... |
+        Tee-Object -FilePath output.log

--- a/behavioral-tests/run.ps1
+++ b/behavioral-tests/run.ps1
@@ -1,0 +1,67 @@
+$invoke_path = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+function doTests
+{
+    param ($InvokePath)
+
+    Set-Location -Path $InvokePath
+
+    $directories = Get-ChildItem -Directory
+
+    $failedTests = @()  # TODO remove after debug
+
+    foreach ($cs in $directories)
+    {
+        Set-Location -Path $cs.FullName
+
+        Write-Output "" | Tee-Object -FilePath output.log
+
+        if (Test-Path .\custom-run.ps1 -PathType Leaf)
+        {
+            $cmd = {
+                .\custom-run.ps1
+            }
+        }
+        else
+        {
+            $cmd = {
+                go run ..\..\cmd\... powershell ..\fake-server.ps1 | Tee-Object -FilePath output.log
+            }
+        }
+
+        $P = Start-Process -PassThru -FilePath "powershell.exe" -ArgumentList "-Command", $cmd.ToString()
+        $P.WaitForExit()
+
+        $diff = Compare-Object -ReferenceObject (Get-Content expected.log) -DifferenceObject (Get-Content output.log) -SyncWindow 0
+
+        if ($null -ne $diff)
+        {
+            Write-Output "${cs}: difference detected in log files"
+            Write-Output $diff
+            $failedTests += $cs
+#            TODO just for debug... failfast later
+#            throw "Difference detected in log files."
+        }
+        else {
+            Remove-Item -Path output.log -Force
+        }
+    }
+
+    # TODO remove after debug
+    if ($failedTests.Count -gt 0) {
+        $cnt = $failedTests.Count
+        Write-Output "Difference detected in log files in ${cnt} tests: $failedTests"
+        throw "Difference detected in log files."
+    }
+
+}
+
+try {
+    doTests $invoke_path
+    Write-Output "OK"
+} catch {
+    Write-Output "FAIL"
+    exit 1
+} finally {
+    Set-Location (Split-Path -Parent $invoke_path)
+}

--- a/cmd/pplog/run_windows.go
+++ b/cmd/pplog/run_windows.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync"
 
 	"github.com/michurin/human-readable-json-logging/slogtotext"
 )
@@ -18,7 +19,10 @@ func runSubprocessMode() {
 	rd, wr := io.Pipe()
 
 	f, g := prepareFormatters()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		err := slogtotext.Read(rd, f, g, 32768)
 		if err != nil {
 			deb("reader is finished with err: " + err.Error())
@@ -43,5 +47,7 @@ func runSubprocessMode() {
 	if exitCode < 0 {
 		exitCode = 1
 	}
+
+	wg.Wait() // allow reader to process records
 	os.Exit(exitCode)
 }

--- a/slogtotext/reader.go
+++ b/slogtotext/reader.go
@@ -47,7 +47,7 @@ func Read(input io.Reader, out func([]Pair) error, outStr func([]Pair) error, ma
 		}
 		bufEnd += n
 		for bufEnd > 0 {
-			s := bytes.IndexByte(buf[:bufEnd], '\n')
+			s, sepLen := findSep(buf[:bufEnd])
 			if s < 0 {
 				if bufEnd == maxCap || noMoreData { // consider full buffer
 					line = buf[:bufEnd]
@@ -59,9 +59,9 @@ func Read(input io.Reader, out func([]Pair) error, outStr func([]Pair) error, ma
 			} else {
 				line = buf[:s]
 				x := make([]byte, maxCap)
-				copy(x, buf[s+1:])
+				copy(x, buf[s+sepLen:])
 				buf = x
-				bufEnd -= s + 1
+				bufEnd -= s + sepLen
 			}
 			data, ok := tryToParse(line)
 			if ok {
@@ -90,4 +90,15 @@ func Read(input io.Reader, out func([]Pair) error, outStr func([]Pair) error, ma
 		}
 	}
 	return nil
+}
+
+func findSep(buf []byte) (int, int) {
+	s := bytes.IndexByte(buf, '\n')
+	sepLen := 1
+	// line sep can be \r\n too
+	if s > 0 && buf[s-1] == '\r' {
+		s--
+		sepLen = 2
+	}
+	return s, sepLen
 }

--- a/slogtotext/reader_test.go
+++ b/slogtotext/reader_test.go
@@ -54,10 +54,12 @@ func TestReader(t *testing.T) {
 		{name: "json", in: `{"a":1}`, exp: `a=1 RAW_INPUT={"a":1}`},
 		{name: "empty", in: "", exp: ""},                                                                // has no effect
 		{name: "nl", in: "\n\n", exp: `"" ("")|"" ("")`},                                                // invalid json
+		{name: "rnl", in: "\r\n\r\n", exp: `"" ("")|"" ("")`},                                           // invalid json
 		{name: "invalid_json", in: `{"a":1}x`, exp: `"{\"a\":1}x" ("")`},                                // as is
 		{name: "invalid_json_with_ctrl", in: `{"a":1}` + "\033" + `x`, exp: `"{\"a\":1}\x1bx" ("yes")`}, // as is with label binary=yes
 		{name: "valid_but_too_long", in: `{"a":"123"}`, exp: `"{\"a\":\"123\"" ("")|"}" ("")`},
 		{name: "valid_but_too_long_and_ok", in: `{"a":"123"}` + "\n" + `{"a":1}`, exp: `"{\"a\":\"123\"" ("")|"}" ("")|a=1 RAW_INPUT={"a":1}`},
+		{name: "valid_but_too_long_and_ok_rn", in: `{"a":"123"}` + "\r\n" + `{"a":1}`, exp: `"{\"a\":\"123\"" ("")|"}" ("")|a=1 RAW_INPUT={"a":1}`},
 	} {
 		cs := cs
 		t.Run(cs.name, func(t *testing.T) {


### PR DESCRIPTION
I've written integration tests for Windows using PowerShell.

And have noticed some issues:
- line separator can be '\r\n', not '\n' only - fixed, see `reader.go`
- windows can loose tail after interruption - known issue - handled by test script, see `behavioral-tests/args-and-signals/custom-run.ps1` comment
- `custom` formatted test fails... not fixed yet

UPD:
- `custom` formatted test fails - fixed, see `run_windows.go`
