### PR TITLE
Functions to skip lines: skipLineIf, skipLineUnless

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ We makes `message` green. Keep shaping your logs field by field.
 - `rmByPfx`
 - `xjson`
 - `xxjson` (experimental)
+- `skipLineIf` — evaluates to empty string, however has side effect: if one of arguments is true, or nonempty string or nonzero integer the line will be skipped and won't appear in output (see [discussion](https://github.com/michurin/human-readable-json-logging/issues/20) and [comment](https://github.com/michurin/human-readable-json-logging/pull/21))
+- `skipLineUnless` — inverted `skipLineIf`, example: `PPLOG_ERRLINE='{{ skipLineUnless .TEXT }}Invalid JONS: {{ .TEXT }}'` — it skips empty lines
 
 ## Template special variables
 

--- a/slogtotext/formatter.go
+++ b/slogtotext/formatter.go
@@ -104,17 +104,11 @@ func tSkipLineIf(x *atomic.Bool, xor bool) func(args ...any) string {
 		for _, v := range args {
 			switch x := v.(type) {
 			case bool:
-				if x {
-					f = true
-				}
+				f = f || x
 			case string:
-				if len(x) > 0 {
-					f = true
-				}
+				f = f || (len(x) > 0)
 			case int:
-				if x != 0 {
-					f = true
-				}
+				f = f || (x != 0)
 			}
 			if f {
 				break

--- a/slogtotext/formatter_test.go
+++ b/slogtotext/formatter_test.go
@@ -85,6 +85,36 @@ func TestFormatter(t *testing.T) {
 			out:      `X`,
 		},
 		{
+			name:     "skip_string_true",
+			template: `{{ skipLineUnless .A }}{{ .M }}`,
+			in:       []slogtotext.Pair{{K: "A", V: "not empty"}, {K: "M", V: "x"}},
+			out:      `x`,
+		},
+		{
+			name:     "skip_string_false",
+			template: `{{ skipLineUnless .A }}{{ .M }}`,
+			in:       []slogtotext.Pair{{K: "A", V: ""}, {K: "M", V: "x"}},
+			out:      ``,
+		},
+		{
+			name:     "skip_int_true",
+			template: `{{ skipLineUnless (len .A) }}{{ .M }}`,
+			in:       []slogtotext.Pair{{K: "A", V: "string"}, {K: "M", V: "x"}},
+			out:      `x`,
+		},
+		{
+			name:     "skip_int_false",
+			template: `{{ skipLineUnless (len .A) }}{{ .M }}`,
+			in:       []slogtotext.Pair{{K: "A", V: ""}, {K: "M", V: "x"}},
+			out:      ``,
+		},
+		{
+			name:     "skip_bool_true",
+			template: `{{ skipLineIf (eq 0 (len .A)) }}{{ .M }}`,
+			in:       []slogtotext.Pair{{K: "A", V: ""}, {K: "M", V: "x"}},
+			out:      ``,
+		},
+		{
 			name:     "sprig_function", // just to be sure that https://masterminds.github.io/sprig/ are on
 			template: `{{ upper "hello" }}`,
 			in:       nil,


### PR DESCRIPTION
How does it work:

Say we have logs with empty lines and different loglevels:

```sh
cat x.log
```

```
Raw line

{"message": "A", "level": "DEBUG"}
{"message":"B","level":"INFO"}
{"message":"C","level":"ERROR"}
```

Let's start from simple setup:

```sh
export PPLOG_LOGLINE='JSON:{{range .ALL}} {{.K}}={{.V}}{{end}}'
export PPLOG_ERRLINE='Invalid JSON: {{.TEXT}}'
cat x.log | go run ./cmd/...
```

Just expected output:

```
Invalid JSON: Raw line
Invalid JSON:
JSON: level=DEBUG message=A
JSON: level=INFO message=B
JSON: level=ERROR message=C
```

Now let's skip empty lines, use `skipLineUnless` (`skipLineIf` exists too):

```sh
export PPLOG_LOGLINE='JSON:{{range .ALL}} {{.K}}={{.V}}{{end}}'
export PPLOG_ERRLINE='{{ skipLineUnless .TEXT }}Invalid JSON: {{.TEXT}}'
cat x.log | go run ./cmd/...
```

No empty lines anymore:

```
Invalid JSON: Raw line
JSON: level=DEBUG message=A
JSON: level=INFO message=B
JSON: level=ERROR message=C
```

Lets remove `DEBUG`:

```sh
export PPLOG_LOGLINE='{{ skipLineIf (eq .level "DEBUG")}}JSON:{{range .ALL}} {{.K}}={{.V}}{{end}}'
export PPLOG_ERRLINE='{{ skipLineUnless .TEXT }}Invalid JSON: {{.TEXT}}'
cat x.log | go run ./cmd/...
```

No empty lines, no debugging:

```
Invalid JSON: Raw line
JSON: level=INFO message=B
JSON: level=ERROR message=C
```

Let's use many conditions: remove DEBUG and INFO:

```sh
export PPLOG_LOGLINE='{{ skipLineIf (eq .level "DEBUG") (eq .level "INFO")}}JSON:{{range .ALL}} {{.K}}={{.V}}{{end}}'
export PPLOG_ERRLINE='{{ skipLineUnless .TEXT }}Invalid JSON: {{.TEXT}}'
cat x.log | go run ./cmd/...
```

The result

```
Invalid JSON: Raw line
JSON: level=ERROR message=C
```

-----

TODO
- [x] tests
- [x] documentations (readme)